### PR TITLE
fix typos

### DIFF
--- a/about/about-app-suite.md
+++ b/about/about-app-suite.md
@@ -54,7 +54,7 @@ Open Policy Agent</td>
 </tr>
 
 <tr>
-<td id="th01"><a href="https://www.openid.net/" target="_blank"><img src="/otomi/img/prometheus_logo.png)/img/openid_logo.svg" alt="Oauth2 / OpenID" width="40"/> </a><br />
+<td id="th01"><a href="https://www.openid.net/" target="_blank"><img src="/otomi/img/openid_logo.svg" alt="Oauth2 / OpenID" width="40"/> </a><br />
 Oauth2 / OpenID</td>
 <td id="th02">Authentication of users against any OIDC provider, or Active Directory / LDAP</td>
 </tr>

--- a/about/about-journey.md
+++ b/about/about-journey.md
@@ -1,6 +1,6 @@
 ---
 slug: development-journey
-title: Development journey
+title: Our development journey
 sidebar_label: Journey
 ---
 
@@ -14,7 +14,7 @@ After having worked with helm charts for a long time this seemed like a natural 
 
 However, we quickly realized we needed a solution to provide variations of the chart values. When you have multiple clusters for different purposes, differences in environment (i.e. dev vs prod) become a differentiating factor. After reviewing the solutions at the time (jsonnet, helmfile) we decided to stay with Go templating and go for [Helmfile](https://github.com/roboll/helmfile). This offered us all the flexibility to achieve what we want: describing stateful configuration while abstracting away the input. Looking back we are glad to have made this choice, and still believe nothing else comes this close to meet our needs. (Only recently was a small helper tool added to k8s core: kustomize. This is however just a small utility, and it does not offer templating.)
 
-After having worked with Helmfile however, we discovered that it offered no real best practices when it comes to coding and management, and might be too flexible to come up with a decent architecture. Some setups in the wild had some degree of sanity, but none offered the developers experience we really wanted. After many evolutions organizing our helmfile architecture we settled on something that we are still very happy with. It uses Helmfile's alphabetic ordering and reminds of a unix runlevel.
+After having worked with Helmfile however, we discovered that it offered no real best practices when it comes to coding and management, and might be too flexible to come up with a decent architecture. Some setups in the wild had some degree of sanity, but none offered the developers experience we really wanted. After many evolutions organizing our helmfile architecture we settled on something that we are still very happy with. It uses Helmfile's alphabetic ordering and reminds of a Unix runlevel.
 
 ### Layered yaml configuration
 
@@ -22,7 +22,7 @@ When modeling configuration for different clusters you come to understand what i
 
 ### Values repo
 
-In the beginning we used our monorepo as is, and kept all the configuration in there as well. But why not make the monorepo stateless itself? And extract the fast moving values to an external storage solution? That offered us the possibility to package up the entire monorepo in a container, and version it. This not only resulted in a clean simple setup in the monorepo with only go templating, but now we have an external repo with yaml configuration that is extremely suitable for GitOps.
+In the beginning we used our monorepo as is, and kept all the configuration in there as well. But why not make the monorepo stateless itself? And extract the fast moving values to an external storage solution? That offered us the possibility to package up the entire monorepo in a container, and version it. This not only resulted in a clean simple setup in the monorepo with only Go templating, but now we have an external repo with yaml configuration that is extremely suitable for GitOps.
 
 From a developers perspective, having made this seperation of concerns made a lot of sense. Only values exist in the repo, so auditing the trail of changes becomes easy. Just look at the commit diff. The core is now essentially a product (albeit one of many parts with lots of glue) that can evolve over time.
 
@@ -30,7 +30,7 @@ From a developers perspective, having made this seperation of concerns made a lo
 
 After having automated the delivery of our monorepo as a docker image, we could finally automate GitOps deployment. However, after having worked with Weave Flux extensively, we came to see that most of these GitOps solutions are an overkill to what we need, and do not support our DRY way of working. Most of the GitOps solutions out there make you use custom resources to tell you what to sync and what not, making you build and maintain a lot of glue to do what should be very easy. We just want to apply changing values using versioned artifacts. We don't want to keep code in sync, just configuration.
 
-So we decided to keep it simple (stupid) and use good old Drone, which is triggered by git to just do what we, as developers do: deploy the changed motherload to the cluster that is interested in receiving those changes. We did not have to deviate from the developers workflow, and could even model it the same way, using the same tooling.
+So we decided to keep it simple (stupid) and use good old Drone, which is triggered by git webhook to just do what we, as developers do: deploy the changed motherload to the cluster that is interested in receiving those changes. We did not have to deviate from the developers workflow, and could even model it the same way, using the same tooling.
 
 One thing that we don't like about it: it is webhook based (push), and does not retry when the hook is not working. We will soon have a solution that allows for periodic syncing.
 

--- a/about/about-vision.md
+++ b/about/about-vision.md
@@ -5,11 +5,11 @@ title: Vision
 
 ## Kubernetes becoming the new foundation
 
-The container space is slowly evolving from the wild west it used to be, into a landscape of governance, security reliability and thus trust. After many years of working with Kubernetes it is not hard to imagine it becoming the foundation for (cloud native) software. That movement already started years ago. We can see that this new DIY architecture paradigm breeds a plethora of containerized solutions and suites offered. And that has become the new reality: too many (possibly good) things to choose from. But this also presents a new opportunity to us: to be able to quickly deploy and test solutions to see if they meets our needs.
+The container space is slowly evolving from the wild west it used to be, into a landscape of governance, security reliability and thus trust. After many years of working with Kubernetes it is not hard to imagine it is becoming the foundation for (cloud native) software. That movement already started years ago. We can see that this new DIY architecture paradigm breeds a plethora of containerized solutions and suites offered. And that has become the new reality: too many (possibly good) things to choose from. But this also presents a new opportunity to us: to be able to quickly deploy and test solutions to see if they meets our needs.
 
 ## What to expect from a container platform
 
-First we have to look at containerization and it's microservice way of working, as it has brought brought focus on the following areas:
+First we have to look at containerization and it's microservice way of working, as it has brought focus on the following areas:
 
 1. **Observability**: State of the (parts of the) system now and over time. Metrics and logs, preferably correlated. Hopefully AI to help us monitor and make sense of it.
 2. **Stateful storage**: Where to keep your crown jewels, and how to automate backups and failover.
@@ -40,7 +40,7 @@ Dealing with this multitude of applications and configuration it is of utmost im
 - Automate everything: input/output validation, testing, deployment, issue management. Limit errors and let developers focus on features.
 - Less integration points: Easily add core apps or wire them together, abstracting configuration away to a single repository.
 - Coding support: deliver jsonschema for validation in your favorite editor (vscode out of the box).
-- API oriented: easily create openapi clients for tasks to do rest operations on the apps, giving autocompletion while developing.
+- API oriented: easily create openapi clients for tasks to do CRUD operations on the apps, giving autocompletion while developing.
 - Sane configuration defaults: wherever possible, provide configuration for the most common use case(s).
 
 Please continue to [our development journey](development-journey) to read about !


### PR DESCRIPTION
It is good reading for those who would like to get familiar with Otomi concepts and philosophy.

I found few typos/missing words while reading About section.

and there is one sentence I think we definitely should enhance

> Otomi Container Platform offers an out-of-the-box enterprise container management platform (on top of Kubernetes) that increases developer efficiency and focuses on results rather than creating complexity. 

No one focuses on creating complexity - everyone tries to avoid it but someones fail to do it.

Maybe this is better:
> Otomi Container Platform offers an out-of-the-box enterprise container management platform (on top of Kubernetes) that increases developer efficiency by reducing operational complexity.